### PR TITLE
Keys should be materialized if dict is changed in loop

### DIFF
--- a/aio_request/aiohttp.py
+++ b/aio_request/aiohttp.py
@@ -69,7 +69,7 @@ class AioHttpDnsResolver(aiohttp.abc.AbstractResolver):
 
             keys_to_pop = []
 
-            for key in self._results.keys():
+            for key in list(self._results.keys()):
                 try:
                     (h, p, f) = key
                     self._results[key] = await self._resolver.resolve(h, p, f)


### PR DESCRIPTION
```
RuntimeError: dictionary changed size during iteration
  File "aiohttp/web.py", line 431, in _run_app
    await runner.cleanup()
  File "aiohttp/web_runner.py", line 294, in cleanup
    await self._cleanup_server()
  File "aiohttp/web_runner.py", line 381, in _cleanup_server
    await self._app.cleanup()
  File "aiohttp/web_app.py", line 430, in cleanup
    await self.on_cleanup.send(self)
  File "aiohttp/signals.py", line 34, in send
    await receiver(*args, **kwargs)  # type: ignore
  File "aiohttp/web_app.py", line 550, in _on_cleanup
    raise errors[0]
  File "aiohttp/web_app.py", line 541, in _on_cleanup
    await it.__anext__()
  File "app.py", line 695, in configure_http_client
    await resolver.close()
  File "aio_request/aiohttp.py", line 62, in close
    await self._task
  File "aio_request/aiohttp.py", line 72, in _resolve
    for key in self._results.keys():
```