### PR TITLE
Expose Headers, PathParameters and QueryParameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v0.2.7 (2026-01-06)
 
-* [Add Headers, PathParameters and QueryParameters to root init file](https://github.com/anna-money/aio-request/pull/312)
+* [Expose Headers, PathParameters and QueryParameters](https://github.com/anna-money/aio-request/pull/312)
 
 
 ## v0.2.6 (2025-12-03)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.2.7 (2026-01-06)
+
+* [Add Headers, PathParameters and QueryParameters to root init file](https://github.com/anna-money/aio-request/pull/312)
+
+
 ## v0.2.6 (2025-12-03)
 
 * [Use LiteralString for url parameter in request functions](https://github.com/anna-money/aio-request/pull/310)

--- a/aio_request/__init__.py
+++ b/aio_request/__init__.py
@@ -2,7 +2,18 @@ import re
 import sys
 from typing import NamedTuple
 
-from .base import ClosableResponse, EmptyResponse, Header, Method, Request, Response, UnexpectedContentTypeError
+from .base import (
+    ClosableResponse,
+    EmptyResponse,
+    Header,
+    Headers,
+    Method,
+    PathParameters,
+    QueryParameters,
+    Request,
+    Response,
+    UnexpectedContentTypeError,
+)
 from .circuit_breaker import (
     CircuitBreaker,
     CircuitBreakerMetrics,
@@ -74,6 +85,7 @@ __all__: tuple[str, ...] = (
     "EmptyResponse",
     "EndpointProvider",
     "Header",
+    "Headers",
     "LowTimeoutModule",
     "Method",
     "MethodBasedStrategy",
@@ -83,7 +95,9 @@ __all__: tuple[str, ...] = (
     "NoopCircuitBreaker",
     "NoopMetricsProvider",
     "ParallelRequestStrategy",
+    "PathParameters",
     "Priority",
+    "QueryParameters",
     "Request",
     "PercentileBasedRequestAttemptDelaysProvider",
     "RequestAttemptDelaysProvider",


### PR DESCRIPTION
To be able to use `aio_request.Headers` instead of `aio_request.base.Headers` and others.