### PR TITLE
Fix dumps callable signature and add bytes support for *_json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.2.9 (2026-01-07)
+
+* [Fix dumps callable signature and add bytes support in request_json](https://github.com/anna-money/aio-request/pull/314)
+
+
 ## v0.2.8 (2026-01-06)
 
 Test build to ensure fetching a version from a tag works

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.2.9 (2026-01-07)
+## v0.2.9 (2026-01-08)
 
 * [Fix dumps callable signature and add bytes support in request_json](https://github.com/anna-money/aio-request/pull/314)
 

--- a/aio_request/request.py
+++ b/aio_request/request.py
@@ -126,7 +126,7 @@ def post_json(
     query_parameters: QueryParameters | None = None,
     headers: Headers | None = None,
     encoding: str = "utf-8",
-    dumps: collections.abc.Callable[[str], Any] = json.dumps,
+    dumps: collections.abc.Callable[[Any], str] = json.dumps,
     content_type: str = "application/json",
     allow_redirects: bool = True,
     max_redirects: int = MAX_REDIRECTS,
@@ -154,7 +154,7 @@ def put_json(
     query_parameters: QueryParameters | None = None,
     headers: Headers | None = None,
     encoding: str = "utf-8",
-    dumps: collections.abc.Callable[[str], Any] = json.dumps,
+    dumps: collections.abc.Callable[[Any], str] = json.dumps,
     content_type: str = "application/json",
     allow_redirects: bool = True,
     max_redirects: int = MAX_REDIRECTS,
@@ -182,7 +182,7 @@ def patch_json(
     query_parameters: QueryParameters | None = None,
     headers: Headers | None = None,
     encoding: str = "utf-8",
-    dumps: collections.abc.Callable[[str], Any] = json.dumps,
+    dumps: collections.abc.Callable[[Any], str] = json.dumps,
     content_type: str = "application/json",
     allow_redirects: bool = True,
     max_redirects: int = MAX_REDIRECTS,
@@ -218,9 +218,7 @@ def request_json(
 ) -> Request:
     enriched_headers = multidict.CIMultiDict[str](headers) if headers is not None else multidict.CIMultiDict[str]()
     enriched_headers.add(Header.CONTENT_TYPE, content_type)
-
-    body = dumps(data).encode(encoding)
-
+    body = data if isinstance(data, bytes) else dumps(data).encode(encoding)
     return request(
         method=method,
         url=url,

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,6 +1,36 @@
 import pytest
 import yarl
 
+from aio_request import patch_json, post_json, put_json, request_json
+
+
+def test_request_json_with_bytes_data() -> None:
+    raw_bytes = b'{"key": "value"}'
+    req = request_json("POST", "api/test", raw_bytes)
+
+    assert req.body == raw_bytes
+
+
+def test_post_json_with_bytes_data() -> None:
+    raw_bytes = b'{"key": "value"}'
+    req = post_json("api/test", raw_bytes)
+
+    assert req.body == raw_bytes
+
+
+def test_put_json_with_bytes_data() -> None:
+    raw_bytes = b'{"key": "value"}'
+    req = put_json("api/test", raw_bytes)
+
+    assert req.body == raw_bytes
+
+
+def test_patch_json_with_bytes_data() -> None:
+    raw_bytes = b'{"key": "value"}'
+    req = patch_json("api/test", raw_bytes)
+
+    assert req.body == raw_bytes
+
 
 @pytest.mark.parametrize(
     "base, relative, actual",


### PR DESCRIPTION
## Summary
- Fix type annotation for `dumps` parameter: `Callable[[str], Any]` → `Callable[[Any], str]`
- Allow passing pre-serialized bytes directly to `request_json` without re-encoding
- Add tests for bytes data handling in `request_json`, `post_json`, `put_json`, `patch_json`

## Test plan
- [x] All existing tests pass (141 tests)
- [x] `make lint` passes
- [x] New tests cover bytes handling for all JSON request methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)